### PR TITLE
Support multi process workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ More configuration parameters:
 - `port`: listen port (defaut: 24231)
 - `metrics_path`: metrics HTTP endpoint (default: /metrics)
 
+When using multiple workers, each worker binds to port + `fluent_worker_id`.
+
 ### prometheus_monitor input plugin
 
 This plugin collects internal metrics in Fluentd. The metrics are similar to/part of [monitor_agent](http://docs.fluentd.org/articles/monitoring#monitoring-agent).
@@ -338,6 +340,7 @@ You can use placeholder for label values. The placeholders will be expanded from
 Reserved placeholders are:
 
 - `${hostname}`: hostname
+- `${worker_id}`: fluent worker id
 - `${tag}`: tag name
 
 

--- a/lib/fluent/plugin/in_prometheus.rb
+++ b/lib/fluent/plugin/in_prometheus.rb
@@ -19,8 +19,19 @@ module Fluent::Plugin
       @registry = ::Prometheus::Client.registry
     end
 
+    def configure(conf)
+      super
+      @port += fluentd_worker_id
+    end
+
+    def multi_workers_ready?
+      true
+    end
+
     def start
       super
+
+      log.debug "listening prometheus http server on http://#{@bind}:#{@port}/#{@metrics_path} for worker#{fluentd_worker_id}"
       @server = WEBrick::HTTPServer.new(
         BindAddress: @bind,
         Port: @port,

--- a/lib/fluent/plugin/in_prometheus_monitor.rb
+++ b/lib/fluent/plugin/in_prometheus_monitor.rb
@@ -16,11 +16,15 @@ module Fluent::Plugin
       @registry = ::Prometheus::Client.registry
     end
 
+    def multi_workers_ready?
+      true
+    end
+
     def configure(conf)
       super
       hostname = Socket.gethostname
       expander = Fluent::Plugin::Prometheus.placeholder_expander(log)
-      placeholders = expander.prepare_placeholders({'hostname' => hostname})
+      placeholders = expander.prepare_placeholders({'hostname' => hostname, 'worker_id' => fluentd_worker_id})
       @base_labels = Fluent::Plugin::Prometheus.parse_labels_elements(conf)
       @base_labels.each do |key, value|
         @base_labels[key] = expander.expand(value, placeholders)

--- a/lib/fluent/plugin/in_prometheus_output_monitor.rb
+++ b/lib/fluent/plugin/in_prometheus_output_monitor.rb
@@ -31,11 +31,15 @@ module Fluent::Plugin
       @registry = ::Prometheus::Client.registry
     end
 
+    def multi_workers_ready?
+      true
+    end
+
     def configure(conf)
       super
       hostname = Socket.gethostname
       expander = Fluent::Plugin::Prometheus.placeholder_expander(log)
-      placeholders = expander.prepare_placeholders({'hostname' => hostname})
+      placeholders = expander.prepare_placeholders({'hostname' => hostname, 'worker_id' => fluentd_worker_id})
       @base_labels = Fluent::Plugin::Prometheus.parse_labels_elements(conf)
       @base_labels.each do |key, value|
         @base_labels[key] = expander.expand(value, placeholders)

--- a/lib/fluent/plugin/in_prometheus_tail_monitor.rb
+++ b/lib/fluent/plugin/in_prometheus_tail_monitor.rb
@@ -20,11 +20,15 @@ module Fluent::Plugin
       @registry = ::Prometheus::Client.registry
     end
 
+    def multi_workers_ready?
+      true
+    end
+
     def configure(conf)
       super
       hostname = Socket.gethostname
       expander = Fluent::Plugin::Prometheus.placeholder_expander(log)
-      placeholders = expander.prepare_placeholders({'hostname' => hostname})
+      placeholders = expander.prepare_placeholders({'hostname' => hostname, 'worker_id' => fluentd_worker_id})
       @base_labels = Fluent::Plugin::Prometheus.parse_labels_elements(conf)
       @base_labels.each do |key, value|
         @base_labels[key] = expander.expand(value, placeholders)


### PR DESCRIPTION
This adds multi process worker feature introduced by Fluentd v0.14.12 to fluent-plugin-prometheus.

Prometheus input plugin starts one HTTP server per worker on sequential port number.
Prometheus input plugins support ${worker_id} placeholder in exported metrics.

This should fix issue #43