### PR TITLE
Added label_key option for counters

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ For details of each metric type, see [Prometheus documentation](http://prometheu
   type counter
   desc The total number of foo in message.
   key foo
+  label_key bar
   <labels>
     tag ${tag}
     host ${hostname}
@@ -244,9 +245,20 @@ For details of each metric type, see [Prometheus documentation](http://prometheu
 - `type`: metric type (required)
 - `desc`: description of this metric (required)
 - `key`: key name of record for instrumentation (**optional**)
+- `label_key`: key name of record with label values (optional)
 - `<labels>`: additional labels for this metric (optional). See [Labels](#labels)
 
 If key is empty, the metric values is treated as 1, so the counter increments by 1 on each record regardless of contents of the record.
+
+If label_key is specified, a label with that name will be added with the value from the record. If the value is an array,
+a counter for each value is incremented. E.g. if you have `label_key exeception` and a record with `record['exception'] = ['MQException', 'InvalidDestinationException']`, you will get these metrics:
+
+```
+metric_name{exception="MQException"} 1.0
+metric_name{exception="InvalidDestinationException"} 1.0
+```
+
+Other labels will be added as specified.
 
 ### gauge type
 

--- a/fluent-plugin-prometheus.gemspec
+++ b/fluent-plugin-prometheus.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "fluent-plugin-prometheus"
-  spec.version       = "1.0.1"
+  spec.version       = "1.1.0"
   spec.authors       = ["Masahiro Sano"]
   spec.email         = ["sabottenda@gmail.com"]
   spec.summary       = %q{A fluent plugin that collects metrics and exposes for Prometheus.}


### PR DESCRIPTION
Add counters with label value from record. Unlike the placeholder functionality, this option will not increment a counter if the field don't exist in the record and update multiple counters if the field is an array of values. See description in README.md