### PR TITLE
Clarify placeholder support

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,9 +340,10 @@ Reserved placeholders are:
 - `${hostname}`: hostname
 - `${worker_id}`: fluent worker id
 - `${tag}`: tag name
+  - only availabe in prometheus output/filter plugin
 
 
-### top-label labels and labels inside metric
+### top-level labels and labels inside metric
 
 Prometheus output/filter plugin can have multiple metric section. Top-level labels section spcifies labels for all metrics. Labels section insede metric section specifis labels for the metric. Both are specified, labels are merged.
 

--- a/lib/fluent/plugin/prometheus.rb
+++ b/lib/fluent/plugin/prometheus.rb
@@ -60,6 +60,7 @@ module Fluent
         placeholder_values = {
           'tag' => tag,
           'hostname' => @hostname,
+          'worker_id' => fluentd_worker_id,
         }
 
         es.each do |time, record|


### PR DESCRIPTION
tag placeholder is not available except for out/filter plugin.
And worker_id placeholder is also available  in out/filter plugin.

fix https://github.com/fluent/fluent-plugin-prometheus/issues/45