### PR TITLE
Use record accessor only when value starts with $. and $[

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,9 +339,11 @@ You can add labels with static value or dynamic value from records. In `promethe
 
 All labels sections has same format. Each lines have key/value for label.
 
-You can use placeholder for label values. The placeholders will be expanded from records or reserved values. If you specify `${foo}`, it will be expanded by value of `foo` in record.
+You can access nested fields in records via dot or bracket notation (https://docs.fluentd.org/v1.0/articles/api-plugin-helper-record_accessor#syntax), for example: `$.kubernetes.namespace`, `$['key1'][0]['key2']`. The record accessor is enable only if the value starts with `$.` or `$[`. Other values are handled as raw string as is and may be expanded by placeholder described later.
 
-You can access nested fields in records via dot or bracket notation (https://docs.fluentd.org/v1.0/articles/api-plugin-helper-record_accessor#syntax), for example: `$.kubernetes.namespace`.
+You can use placeholder for label values. The placeholders will be expanded from reserved values and records.
+If you specify `${hostname}`, it will be expanded by value of a hostname where fluentd runs.
+The placeholder for records is deprecated. Use record accessor syntax instead.
 
 Reserved placeholders are:
 

--- a/lib/fluent/plugin/in_prometheus_monitor.rb
+++ b/lib/fluent/plugin/in_prometheus_monitor.rb
@@ -27,7 +27,9 @@ module Fluent::Plugin
       placeholders = expander.prepare_placeholders({'hostname' => hostname, 'worker_id' => fluentd_worker_id})
       @base_labels = Fluent::Plugin::Prometheus.parse_labels_elements(conf)
       @base_labels.each do |key, value|
-        @base_labels[key] = expander.expand(value, placeholders)
+        if value.is_a?(String)
+          @base_labels[key] = expander.expand(value, placeholders)
+        end
       end
 
       if defined?(Fluent::Plugin) && defined?(Fluent::Plugin::MonitorAgentInput)

--- a/spec/fluent/plugin/in_prometheus_monitor_spec.rb
+++ b/spec/fluent/plugin/in_prometheus_monitor_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+require 'fluent/plugin/in_prometheus_monitor'
+require 'fluent/test/driver/input'
+
+describe Fluent::Plugin::PrometheusMonitorInput do
+  MONITOR_CONFIG = %[
+  @type prometheus_monitor
+  <labels>
+    host ${hostname}
+    foo bar
+    no_effect1 $.foo.bar
+    no_effect2 $[0][1]
+  </labels>
+]
+
+  let(:config) { MONITOR_CONFIG }
+  let(:port) { 24231 }
+  let(:driver) { Fluent::Test::Driver::Input.new(Fluent::Plugin::PrometheusMonitorInput).configure(config) }
+
+  describe '#configure' do
+    it 'does not raise error' do
+      expect{driver}.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
We started using RecordAccessor to expand labels value with record values. RecordAccessor class cannot be used with RecordTransformer, so fixed to use RecordAccessor only when labels value start with `$.` and `$[`.

Also add tests for record accessors and in_prometheus_monitor plugin. in_promethesu_monitor uses funtionality for expanding placeholder in configuration time, which results in plugin crashed on bootstrap even if tests passed.

Fixes #66 