### PR TITLE
Add more worker support

### DIFF
--- a/lib/fluent/plugin/filter_prometheus.rb
+++ b/lib/fluent/plugin/filter_prometheus.rb
@@ -11,6 +11,10 @@ module Fluent::Plugin
       @registry = ::Prometheus::Client.registry
     end
 
+    def multi_workers_ready?
+      true
+    end
+
     def configure(conf)
       super
       labels = Fluent::Plugin::Prometheus.parse_labels_elements(conf)

--- a/lib/fluent/plugin/in_prometheus_monitor.rb
+++ b/lib/fluent/plugin/in_prometheus_monitor.rb
@@ -39,6 +39,11 @@ module Fluent::Plugin
         @monitor_agent = Fluent::MonitorAgentInput.new
       end
 
+    end
+
+    def start
+      super
+
       buffer_queue_length = @registry.gauge(
         :fluentd_status_buffer_queue_length,
         'Current buffer queue length.')
@@ -54,10 +59,6 @@ module Fluent::Plugin
         'buffer_total_queued_size' => buffer_total_queued_size,
         'retry_count' => retry_counts,
       }
-    end
-
-    def start
-      super
       timer_execute(:in_prometheus_monitor, @interval, &method(:update_monitor_info))
     end
 

--- a/lib/fluent/plugin/in_prometheus_output_monitor.rb
+++ b/lib/fluent/plugin/in_prometheus_output_monitor.rb
@@ -51,6 +51,10 @@ module Fluent::Plugin
       else
         @monitor_agent = Fluent::MonitorAgentInput.new
       end
+    end
+
+    def start
+      super
 
       @metrics = {
         buffer_queue_length: @registry.gauge(
@@ -81,10 +85,6 @@ module Fluent::Plugin
           :fluentd_output_status_retry_wait,
           'Current retry wait'),
       }
-    end
-
-    def start
-      super
       timer_execute(:in_prometheus_output_monitor, @interval, &method(:update_monitor_info))
     end
 

--- a/lib/fluent/plugin/in_prometheus_tail_monitor.rb
+++ b/lib/fluent/plugin/in_prometheus_tail_monitor.rb
@@ -40,6 +40,10 @@ module Fluent::Plugin
       else
         @monitor_agent = Fluent::MonitorAgentInput.new
       end
+    end
+
+    def start
+      super
 
       @metrics = {
         position: @registry.gauge(
@@ -49,10 +53,6 @@ module Fluent::Plugin
           :fluentd_tail_file_inode,
           'Current inode of file.'),
       }
-    end
-
-    def start
-      super
       timer_execute(:in_prometheus_tail_monitor, @interval, &method(:update_monitor_info))
     end
 

--- a/lib/fluent/plugin/out_prometheus.rb
+++ b/lib/fluent/plugin/out_prometheus.rb
@@ -11,6 +11,10 @@ module Fluent::Plugin
       @registry = ::Prometheus::Client.registry
     end
 
+    def multi_workers_ready?
+      true
+    end
+
     def configure(conf)
       super
       labels = Fluent::Plugin::Prometheus.parse_labels_elements(conf)


### PR DESCRIPTION
- To avoid duplicated metrics error, move metrics registration to `start` method. See also commit comment: https://github.com/fluent/fluent-plugin-prometheus/pull/82/commits/03eff9b1fbb3cd33f91ae9db377bee6c46da5048
- `prometheus` output/filter works on multi workers.