### PR TITLE
add validation for invalid use of record accessor syntax

### DIFF
--- a/lib/fluent/plugin/in_prometheus_monitor.rb
+++ b/lib/fluent/plugin/in_prometheus_monitor.rb
@@ -27,9 +27,10 @@ module Fluent::Plugin
       placeholders = expander.prepare_placeholders({'hostname' => hostname, 'worker_id' => fluentd_worker_id})
       @base_labels = Fluent::Plugin::Prometheus.parse_labels_elements(conf)
       @base_labels.each do |key, value|
-        if value.is_a?(String)
-          @base_labels[key] = expander.expand(value, placeholders)
+        unless value.is_a?(String)
+          raise Fluent::ConfigError, "record accessor syntax is not available in prometheus_monitor"
         end
+        @base_labels[key] = expander.expand(value, placeholders)
       end
 
       if defined?(Fluent::Plugin) && defined?(Fluent::Plugin::MonitorAgentInput)

--- a/lib/fluent/plugin/in_prometheus_output_monitor.rb
+++ b/lib/fluent/plugin/in_prometheus_output_monitor.rb
@@ -42,6 +42,9 @@ module Fluent::Plugin
       placeholders = expander.prepare_placeholders({'hostname' => hostname, 'worker_id' => fluentd_worker_id})
       @base_labels = Fluent::Plugin::Prometheus.parse_labels_elements(conf)
       @base_labels.each do |key, value|
+        unless value.is_a?(String)
+          raise Fluent::ConfigError, "record accessor syntax is not available in prometheus_output_monitor"
+        end
         @base_labels[key] = expander.expand(value, placeholders)
       end
 

--- a/lib/fluent/plugin/in_prometheus_tail_monitor.rb
+++ b/lib/fluent/plugin/in_prometheus_tail_monitor.rb
@@ -31,6 +31,9 @@ module Fluent::Plugin
       placeholders = expander.prepare_placeholders({'hostname' => hostname, 'worker_id' => fluentd_worker_id})
       @base_labels = Fluent::Plugin::Prometheus.parse_labels_elements(conf)
       @base_labels.each do |key, value|
+        unless value.is_a?(String)
+          raise Fluent::ConfigError, "record accessor syntax is not available in prometheus_tail_monitor"
+        end
         @base_labels[key] = expander.expand(value, placeholders)
       end
 

--- a/spec/fluent/plugin/in_prometheus_monitor_spec.rb
+++ b/spec/fluent/plugin/in_prometheus_monitor_spec.rb
@@ -8,8 +8,17 @@ describe Fluent::Plugin::PrometheusMonitorInput do
   <labels>
     host ${hostname}
     foo bar
-    no_effect1 $.foo.bar
-    no_effect2 $[0][1]
+  </labels>
+]
+
+  INVALID_MONITOR_CONFIG = %[
+  @type prometheus_monitor
+
+  <labels>
+    host ${hostname}
+    foo bar
+    invalid_use1 $.foo.bar
+    invalid_use2 $[0][1]
   </labels>
 ]
 
@@ -18,8 +27,17 @@ describe Fluent::Plugin::PrometheusMonitorInput do
   let(:driver) { Fluent::Test::Driver::Input.new(Fluent::Plugin::PrometheusMonitorInput).configure(config) }
 
   describe '#configure' do
-    it 'does not raise error' do
-      expect{driver}.not_to raise_error
+    describe 'valid' do
+      it 'does not raise error' do
+        expect{driver}.not_to raise_error
+      end
+    end
+
+    describe 'invalid' do
+      let(:config) { INVALID_MONITOR_CONFIG }
+      it 'expect raise error' do
+        expect{driver}.to raise_error
+      end
     end
   end
 end


### PR DESCRIPTION
ref #80 

record accessor syntax is only available in prometheus filter/output plugins because it populates label from messages but other plugins does not handle message directly. To avoid invalid use add validation.
