### PR TITLE
Added support for additional placeholders from record_transform filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,8 +351,10 @@ Reserved placeholders are:
 
 - `${hostname}`: hostname
 - `${worker_id}`: fluent worker id
-- `${tag}`: tag name
-  - only available in Prometheus output/filter plugin
+- `${tag}`: tag name, only available in Prometheus output/filter plugin
+- `${tag_parts[N]}`: refers to the Nth part of the tag, only available in Prometheus output/filter plugin
+- `${tag_suffix}`: refers to the [N..] part of the tag, only available in Prometheus output/filter plugin
+- `${tag_prefix}`: refers to the [0..N] part of the tag, only available in Prometheus output/filter plugin
 
 
 ### top-level labels and labels inside metric

--- a/lib/fluent/plugin/prometheus.rb
+++ b/lib/fluent/plugin/prometheus.rb
@@ -67,9 +67,35 @@ module Fluent
         @hostname = Socket.gethostname
       end
 
+      def tag_prefix(tag_parts)
+        return [] if tag_parts.empty?
+        tag_prefix = [tag_parts.first]
+        1.upto(tag_parts.size-1).each do |i|
+          tag_prefix[i] = "#{tag_prefix[i-1]}.#{tag_parts[i]}"
+        end
+        tag_prefix
+      end
+  
+      def tag_suffix(tag_parts)
+        return [] if tag_parts.empty?
+        rev_tag_parts = tag_parts.reverse
+        rev_tag_suffix = [rev_tag_parts.first]
+        1.upto(tag_parts.size-1).each do |i|
+          rev_tag_suffix[i] = "#{rev_tag_parts[i]}.#{rev_tag_suffix[i-1]}"
+        end
+        rev_tag_suffix.reverse!
+      end      
+
       def instrument(tag, es, metrics)
+        tag_parts = tag.split('.')
+        tag_prefix = tag_prefix(tag_parts)
+        tag_suffix = tag_suffix(tag_parts)
+          
         placeholder_values = {
           'tag' => tag,
+          'tag_parts'  => tag_parts,
+          'tag_prefix' => tag_prefix,
+          'tag_suffix' => tag_suffix,          
           'hostname' => @hostname,
           'worker_id' => fluentd_worker_id,
         }


### PR DESCRIPTION
I have added additional flexibility to the prometheus filter to be able to define the labels based on parts of the tag, with inspiration from record_filter_transformer