### PR TITLE
Export the oldest and newest timekeys in each buffer

### DIFF
--- a/lib/fluent/plugin/in_prometheus_monitor.rb
+++ b/lib/fluent/plugin/in_prometheus_monitor.rb
@@ -45,6 +45,12 @@ module Fluent::Plugin
     def start
       super
 
+      @buffer_newest_timekey = @registry.gauge(
+        :fluentd_status_buffer_newest_timekey,
+        'Newest timekey in buffer.')
+      @buffer_oldest_timekey = @registry.gauge(
+        :fluentd_status_buffer_oldest_timekey,
+        'Oldest timekey in buffer.')
       buffer_queue_length = @registry.gauge(
         :fluentd_status_buffer_queue_length,
         'Current buffer queue length.')
@@ -65,10 +71,18 @@ module Fluent::Plugin
 
     def update_monitor_info
       @monitor_agent.plugins_info_all.each do |info|
+        label = labels(info)
+
         @monitor_info.each do |name, metric|
           if info[name]
-            metric.set(labels(info), info[name])
+            metric.set(label, info[name])
           end
+        end
+
+        timekeys = info["buffer_timekeys"]
+        if timekeys && !timekeys.empty?
+          @buffer_newest_timekey.set(label, timekeys.max)
+          @buffer_oldest_timekey.set(label, timekeys.min)
         end
       end
     end

--- a/lib/fluent/plugin/in_prometheus_output_monitor.rb
+++ b/lib/fluent/plugin/in_prometheus_output_monitor.rb
@@ -60,6 +60,12 @@ module Fluent::Plugin
       super
 
       @metrics = {
+        buffer_newest_timekey: @registry.gauge(
+          :fluentd_output_status_buffer_newest_timekey,
+          'Newest timekey in buffer.'),
+        buffer_oldest_timekey: @registry.gauge(
+          :fluentd_output_status_buffer_oldest_timekey,
+          'Oldest timekey in buffer.'),
         buffer_queue_length: @registry.gauge(
           :fluentd_output_status_buffer_queue_length,
           'Current buffer queue length.'),
@@ -121,6 +127,12 @@ module Fluent::Plugin
           if info[name]
             metric.set(label, info[name])
           end
+        end
+
+        timekeys = info["buffer_timekeys"]
+        if timekeys && !timekeys.empty?
+          @metrics[:buffer_newest_timekey].set(label, timekeys.max)
+          @metrics[:buffer_oldest_timekey].set(label, timekeys.min)
         end
 
         if info['instance_variables']


### PR DESCRIPTION
A metric listing all timekeys in each buffer was added to fluentd in <https://github.com/fluent/fluentd/pull/2343>. This exports the oldest and newest values in that list as Prometheus metrics. See discussion in <https://github.com/fluent/fluent-plugin-prometheus/issues/89> for context and rationale.