### PR TITLE
Expose flush_time_count and slow_flush_count metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ This plugin collects internal metrics in Fluentd. The metrics are similar to/par
 
 Current exposed metrics:
 
-- `buffere_queue_length` of each BufferedOutput plugins
+- `buffer_queue_length` of each BufferedOutput plugins
 - `buffer_total_queued_size` of each BufferedOutput plugins
 - `retry_count` of each BufferedOutput plugins
 
@@ -97,6 +97,8 @@ Current exposed metrics:
 - `fluentd_output_status_retry_count`
 - `fluentd_output_status_num_errors`
 - `fluentd_output_status_emit_count`
+- `fluentd_output_status_flush_time_count`
+- `fluentd_output_status_slow_flush_count`
 - `fluentd_output_status_retry_wait`
     - current retry_wait computed from last retry time and next retry time
 - `fluentd_output_status_emit_records`

--- a/lib/fluent/plugin/in_prometheus_output_monitor.rb
+++ b/lib/fluent/plugin/in_prometheus_output_monitor.rb
@@ -24,6 +24,10 @@ module Fluent::Plugin
       :emit_records,
       :write_count,
       :rollback_count,
+
+      # from v1.6.0
+      :flush_time_count,
+      :slow_flush_count,
     ]
 
     def initialize
@@ -84,6 +88,12 @@ module Fluent::Plugin
         rollback_count: @registry.gauge(
           :fluentd_output_status_rollback_count,
           'Current rollback counts.'),
+        flush_time_count: @registry.gauge(
+          :fluentd_output_status_flush_time_count,
+          'Total flush time.'),
+        slow_flush_count: @registry.gauge(
+          :fluentd_output_status_slow_flush_count,
+          'Current slow flush counts.'),
         retry_wait: @registry.gauge(
           :fluentd_output_status_retry_wait,
           'Current retry wait'),
@@ -112,6 +122,8 @@ module Fluent::Plugin
         emit_count: @metrics[:emit_count],
         emit_records: @metrics[:emit_records],
         rollback_count: @metrics[:rollback_count],
+        flush_time_count: @metrics[:flush_time_count],
+        slow_flush_count: @metrics[:slow_flush_count],
       }
 
       agent_info.each do |info|


### PR DESCRIPTION
Expose `flush_time_count` and `slow_flush_count` metrics that were implemented in https://github.com/fluent/fluentd/pull/2450.