### PR TITLE
add more metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,16 @@ When using multiple workers, each worker binds to port + `fluent_worker_id`.
 
 This plugin collects internal metrics in Fluentd. The metrics are similar to/part of [monitor_agent](https://docs.fluentd.org/input/monitor_agent).
 
-Current exposed metrics:
 
-- `buffer_queue_length` of each BufferedOutput plugins
-- `buffer_total_queued_size` of each BufferedOutput plugins
-- `retry_count` of each BufferedOutput plugins
+#### Exposed metrics
+
+- `fluentd_status_buffer_queue_length`
+- `fluentd_status_buffer_total_queued_size`
+- `fluentd_status_retry_count`
+- `fluentd_status_buffer_newest_timekey` from fluentd v1.4.2
+- `fluentd_status_buffer_oldest_timekey` from fluentd v1.4.2
+
+#### Configuration
 
 With following configuration, those metrics are collected.
 
@@ -86,28 +91,35 @@ More configuration parameters:
 
 ### prometheus_output_monitor input plugin
 
-**experimental**
-
 This plugin collects internal metrics for output plugin in Fluentd. This is similar to `prometheus_monitor` plugin, but specialized for output plugin. There are Many metrics `prometheus_monitor` does not include, such as `num_errors`, `retry_wait` and so on.
 
-Current exposed metrics:
+#### Exposed metrics
 
-- `fluentd_output_status_buffer_queue_length`
-- `fluentd_output_status_buffer_total_bytes`
+Metrics for output
+
 - `fluentd_output_status_retry_count`
 - `fluentd_output_status_num_errors`
 - `fluentd_output_status_emit_count`
-- `fluentd_output_status_flush_time_count`
-- `fluentd_output_status_slow_flush_count`
 - `fluentd_output_status_retry_wait`
     - current retry_wait computed from last retry time and next retry time
 - `fluentd_output_status_emit_records`
-    - only for v0.14
 - `fluentd_output_status_write_count`
-    - only for v0.14
 - `fluentd_output_status_rollback_count`
-    - only for v0.14
+- `fluentd_output_status_flush_time_count` from fluentd v1.16.0
+- `fluentd_output_status_slow_flush_count` from fluentd v1.16.0
 
+Metrics for buffer
+
+- `fluentd_output_status_buffer_total_bytes`
+- `fluentd_output_status_buffer_stage_length` from fluentd v1.16.0
+- `fluentd_output_status_buffer_stage_byte_size` from fluentd v1.16.0
+- `fluentd_output_status_buffer_queue_length`
+- `fluentd_output_status_buffer_queue_byte_size` from fluentd v1.16.0
+- `fluentd_output_status_buffer_newest_timekey` from fluentd v1.16.0
+- `fluentd_output_status_buffer_oldest_timekey` from fluentd v1.16.0
+- `fluentd_output_status_buffer_available_space_ratio` from fluentd v1.16.0
+
+#### Configuration
 
 With following configuration, those metrics are collected.
 
@@ -124,13 +136,11 @@ More configuration parameters:
 
 ### prometheus_tail_monitor input plugin
 
-**experimental**
-
 This plugin collects internal metrics for in_tail plugin in Fluentd. in_tail plugin holds internal state for files that the plugin is watching. The state is sometimes important to monitor plugins work correctly.
 
 This plugin uses internal class of Fluentd, so it's easy to break.
 
-Current exposed metrics:
+#### Exposed metrics
 
 - `fluentd_tail_file_position`
     - Current bytes which plugin reads from the file
@@ -142,6 +152,8 @@ Default labels:
 - `plugin_id`: a value set for a plugin in configuration.
 - `type`: plugin name. `in_tail` only for now.
 - `path`: file path
+
+#### Configuration
 
 With following configuration, those metrics are collected.
 

--- a/lib/fluent/plugin/in_prometheus_output_monitor.rb
+++ b/lib/fluent/plugin/in_prometheus_output_monitor.rb
@@ -64,18 +64,33 @@ module Fluent::Plugin
       super
 
       @metrics = {
+        # Buffer metrics
+        buffer_total_queued_size: @registry.gauge(
+          :fluentd_output_status_buffer_total_bytes,
+          'Current total size of stage and queue buffers.'),
+        buffer_stage_length: @registry.gauge(
+          :fluentd_output_status_buffer_stage_length,
+          'Current length of stage buffers.'),
+        buffer_stage_byte_size: @registry.gauge(
+          :fluentd_output_status_buffer_stage_byte_size,
+          'Current total size of stage buffers.'),
+        buffer_queue_length: @registry.gauge(
+          :fluentd_output_status_buffer_queue_length,
+          'Current length of queue buffers.'),
+        buffer_queue_byte_size: @registry.gauge(
+          :fluentd_output_status_queue_byte_size,
+          'Current total size of queue buffers.'),
+        buffer_available_buffer_space_ratios: @registry.gauge(
+          :fluentd_output_status_buffer_available_space_ratio,
+          'Ratio of available space in buffer.'),
         buffer_newest_timekey: @registry.gauge(
           :fluentd_output_status_buffer_newest_timekey,
           'Newest timekey in buffer.'),
         buffer_oldest_timekey: @registry.gauge(
           :fluentd_output_status_buffer_oldest_timekey,
           'Oldest timekey in buffer.'),
-        buffer_queue_length: @registry.gauge(
-          :fluentd_output_status_buffer_queue_length,
-          'Current buffer queue length.'),
-        buffer_total_queued_size: @registry.gauge(
-          :fluentd_output_status_buffer_total_bytes,
-          'Current total size of queued buffers.'),
+
+        # Output metrics
         retry_counts: @registry.gauge(
           :fluentd_output_status_retry_count,
           'Current retry counts.'),
@@ -118,8 +133,17 @@ module Fluent::Plugin
       }
 
       monitor_info = {
-        'buffer_queue_length' => @metrics[:buffer_queue_length],
+        # buffer metrics
         'buffer_total_queued_size' => @metrics[:buffer_total_queued_size],
+        'buffer_stage_length' => @metrics[:buffer_stage_length],
+        'buffer_stage_byte_size' => @metrics[:buffer_stage_byte_size],
+        'buffer_queue_length' => @metrics[:buffer_queue_length],
+        'buffer_queue_byte_size' => @metrics[:buffer_queue_byte_size],
+        'buffer_available_buffer_space_ratios' => @metrics[:buffer_available_buffer_space_ratios],
+        'buffer_newest_timekey' => @metrics[:buffer_newest_timekey],
+        'buffer_oldest_timekey' => @metrics[:buffer_oldest_timekey],
+
+        # output metrics
         'retry_count' => @metrics[:retry_counts],
       }
       instance_vars_info = {
@@ -139,12 +163,6 @@ module Fluent::Plugin
           if info[name]
             metric.set(label, info[name])
           end
-        end
-
-        timekeys = info["buffer_timekeys"]
-        if timekeys && !timekeys.empty?
-          @metrics[:buffer_newest_timekey].set(label, timekeys.max)
-          @metrics[:buffer_oldest_timekey].set(label, timekeys.min)
         end
 
         if info['instance_variables']


### PR DESCRIPTION
Signed-off-by: Masahiro Sano <sabottenda@gmail.com>

It seems fluentd supports more metrics for Buffer.
From Fluent v1.16.0 by this PR https://github.com/fluent/fluentd/pull/2450, in_monitor_agent plugin gets the statistics from each plugin. 

Now `prometheus_output_monitor` plugin gets almost all metrics from them via monitor_agent. So it should be the same behavior of `prometheus_monitor` actually... Anyway those metrics are supported only in `prometheus_output_monitor` for now.