### PR TITLE
Restricts prometheus-client version

### DIFF
--- a/fluent-plugin-prometheus.gemspec
+++ b/fluent-plugin-prometheus.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "fluentd", ">= 0.14.20", "< 2"
-  spec.add_dependency "prometheus-client"
+  spec.add_dependency "prometheus-client", "~> 0.4.2"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
hotfix for https://github.com/fluent/fluent-plugin-prometheus/issues/119

New version(0.10.0) has no compatibility with an older version.

This is a temporary solution. We need to catch up new version of prometeus-ruby.

