### PR TITLE
pin prometheus client version

### DIFF
--- a/fluent-plugin-prometheus.gemspec
+++ b/fluent-plugin-prometheus.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "fluentd", ">= 0.14.20", "< 2"
-  spec.add_dependency "prometheus-client"
+  spec.add_dependency "prometheus-client", "< 0.10"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
The latest ruby client for prometheus seems to be incompatible with this plugin:

```
/ $ gem list | grep promethe
fluent-plugin-prometheus (1.6.0)
prometheus-client (0.10.0)
```
I get this on fluentd startup:
```
2019-10-08 12:00:53 +0000 [error]: #0 unexpected error error_class=ArgumentError error="wrong number of arguments (given 2, expected 1; required keyword: docstring)"
  2019-10-08 12:00:53 +0000 [error]: #0 /usr/lib/ruby/gems/2.5.0/gems/prometheus-client-0.10.0/lib/prometheus/client/registry.rb:56:in `gauge'
  2019-10-08 12:00:53 +0000 [error]: #0 /usr/lib/ruby/gems/2.5.0/gems/fluent-plugin-prometheus-1.6.0/lib/fluent/plugin/in_prometheus_output_monitor.rb:69:in `start'
  2019-10-08 12:00:53 +0000 [error]: #0 /usr/lib/ruby/gems/2.5.0/gems/fluentd-1.6.3/lib/fluent/compat/call_super_mixin.rb:42:in `start'
```
I don't know enough ruby to resolve the alleged compatibility problems, but pinning the client version fixes the issue for me.

see: https://github.com/prometheus/client_ruby/pull/95