### PR TITLE
implement Flunet::Filter#filter instead of Flunet::Filter#filter_stream

### DIFF
--- a/lib/fluent/plugin/filter_prometheus.rb
+++ b/lib/fluent/plugin/filter_prometheus.rb
@@ -22,9 +22,9 @@ module Fluent::Plugin
       @metrics = Fluent::Plugin::Prometheus.parse_metrics_elements(conf, @registry, labels)
     end
 
-    def filter_stream(tag, es)
-      instrument(tag, es, @metrics)
-      es
+    def filter(tag, time, record)
+      instrument(tag, { time => record }, @metrics)
+      record
     end
   end
 end

--- a/lib/fluent/plugin/filter_prometheus.rb
+++ b/lib/fluent/plugin/filter_prometheus.rb
@@ -23,7 +23,7 @@ module Fluent::Plugin
     end
 
     def filter(tag, time, record)
-      instrument(tag, { time => record }, @metrics)
+      instrument_single(tag, time, record, @metrics)
       record
     end
   end

--- a/lib/fluent/plugin/prometheus.rb
+++ b/lib/fluent/plugin/prometheus.rb
@@ -113,12 +113,11 @@ module Fluent
       end
 
       def instrument(tag, es, metrics)
-        @placeholder_values[tag] ||= {
+        placeholder_values = {
           'tag' => tag,
           'hostname' => @hostname,
           'worker_id' => fluentd_worker_id,
         }
-        placeholder_values = @placeholder_values[tag]
 
         es.each do |time, record|
           placeholders = record.merge(placeholder_values)

--- a/lib/fluent/plugin/prometheus.rb
+++ b/lib/fluent/plugin/prometheus.rb
@@ -88,19 +88,20 @@ module Fluent
 
       def configure(conf)
         super
+        @placeholder_values = {}
         @placeholder_expander = Fluent::Plugin::Prometheus.placeholder_expander(log)
         @hostname = Socket.gethostname
       end
 
       def instrument(tag, es, metrics)
-        placeholder_values = {
+        @placeholder_values[tag] ||= {
           'tag' => tag,
           'hostname' => @hostname,
           'worker_id' => fluentd_worker_id,
         }
 
         es.each do |time, record|
-          placeholders = record.merge(placeholder_values)
+          placeholders = record.merge(@placeholder_values[tag])
           placeholders = @placeholder_expander.prepare_placeholders(placeholders)
           metrics.each do |metric|
             begin

--- a/lib/fluent/plugin/prometheus.rb
+++ b/lib/fluent/plugin/prometheus.rb
@@ -99,9 +99,10 @@ module Fluent
           'hostname' => @hostname,
           'worker_id' => fluentd_worker_id,
         }
+        placeholder_values = @placeholder_values[tag]
 
         es.each do |time, record|
-          placeholders = record.merge(@placeholder_values[tag])
+          placeholders = record.merge(placeholder_values)
           placeholders = @placeholder_expander.prepare_placeholders(placeholders)
           metrics.each do |metric|
             begin


### PR DESCRIPTION
Default implementation of
[Flunet::Filter#filter_stream](https://github.com/fluent/fluentd/blob/077508ac817b7637307434d0c978d7cdc3d1c534/lib/fluent/plugin/filter.rb#L48-L70)
has rescue statement by default. so if received record is invalid, it would work without any error.
 and It can be faster by using fileter optimization
feature (https://docs.fluentd.org/filter#filter-chain-optimization)