### PR TITLE
Add out_prometheus_pushgateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,25 @@ You can access nested keys in records via dot or bracket notation (https://docs.
 
 See Supported Metric Type and Labels for more configuration parameters.
 
+### prometheus_pushgateway output plugin
+
+You can configure this plugin to push metrics to [Pushgateway](https://github.com/prometheus/pushgateway) collected by other Prometheus plugins.
+With following configuration, you can push data.
+
+```
+<match>
+  @type prometheus_pushgateway
+  job_name fluentd_prometheus_pushgateway
+</match>
+```
+
+More configuration parameters:
+
+- `gateway`: binding interface (default: 'http://localhost:9091')
+- `job_name`: job name. this value must be a unique (required)
+- `instance`: instance name (default: nil)
+- `push_interval`: the interval of pushing data to pushgateway
+
 ## Supported Metric Types
 
 For details of each metric type, see [Prometheus documentation](http://prometheus.io/docs/concepts/metric_types/). Also see [metric name guide](http://prometheus.io/docs/practices/naming/).

--- a/lib/fluent/plugin/out_prometheus_pushgateway.rb
+++ b/lib/fluent/plugin/out_prometheus_pushgateway.rb
@@ -1,0 +1,63 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'prometheus/client/push'
+require 'fluent/plugin/output'
+
+module Fluent::Plugin
+  class PrometheusPushgatewayOutput < Fluent::Plugin::Output
+    Fluent::Plugin.register_output('prometheus_pushgateway', self)
+
+    helpers :timer
+
+    desc 'The endpoint of pushgateway'
+    config_param :gateway, :string, default: 'http://localhost:9091'
+    desc 'job name. this value must be unique between instances'
+    config_param :job_name, :string
+    desc 'instance name'
+    config_param :instance, :string, default: nil
+    desc 'the interval of pushing data to pushgateway'
+    config_param :push_interval, :time, default: 3
+
+    def initialize
+      super
+
+      @registry = ::Prometheus::Client.registry
+    end
+
+    def multi_workers_ready?
+      true
+    end
+
+    def configure(conf)
+      super
+
+      @push_client = ::Prometheus::Client::Push.new("#{@job_name}:#{fluentd_worker_id}", @instance, @gateway)
+    end
+
+    def start
+      super
+
+      timer_execute(:out_prometheus_pushgateway, @push_interval) do
+        @push_client.add(@registry)
+      end
+    end
+
+    def process(tag, es)
+      # nothing
+    end
+  end
+end

--- a/misc/pushgateway.conf
+++ b/misc/pushgateway.conf
@@ -1,0 +1,22 @@
+<source>
+  @type dummy
+  tag dummy
+</source>
+
+<filter dummy>
+  @type prometheus
+
+  <metric>
+    name fluent_in_dummy_message
+    type counter
+    desc dummy messsage count
+    <labels>
+      host ${hostname}
+    </labels>
+  </metric>
+</filter>
+
+<match dummy>
+  @type prometheus_pushgateway
+  job_name fleuntd_prometheus_pushgateway
+</match>


### PR DESCRIPTION
Support [pushgateway](https://github.com/prometheus/pushgateway) to push metrics instead of being scrapped by Prometheus.
pushgateway interface of prometheus/client_ruby is https://github.com/prometheus/client_ruby/tree/v0.9.0#pushgateway
