### PR TITLE
use at type

### DIFF
--- a/spec/fluent/plugin/in_prometheus_spec.rb
+++ b/spec/fluent/plugin/in_prometheus_spec.rb
@@ -6,11 +6,11 @@ require 'net/http'
 
 describe Fluent::Plugin::PrometheusInput do
   CONFIG = %[
-  type prometheus
+  @type prometheus
 ]
 
   LOCAL_CONFIG = %[
-  type prometheus
+  @type prometheus
   bind 127.0.0.1
 ]
 

--- a/spec/fluent/plugin/shared.rb
+++ b/spec/fluent/plugin/shared.rb
@@ -1,6 +1,6 @@
 
 BASE_CONFIG = %[
-  type prometheus
+  @type prometheus
 ]
 
 SIMPLE_CONFIG = BASE_CONFIG + %[


### PR DESCRIPTION
Use `@type` because type is deprecated