### PR TITLE
Use mount_proc instead of mount

### DIFF
--- a/lib/fluent/plugin/in_prometheus.rb
+++ b/lib/fluent/plugin/in_prometheus.rb
@@ -32,12 +32,6 @@ module Fluent::Plugin
       config_param :extra_conf, :hash, default: {:SSLCertName => [['CN','nobody'],['DC','example']]}, symbolize_keys: true
     end
 
-    attr_reader :registry
-
-    attr_reader :num_workers
-    attr_reader :base_port
-    attr_reader :metrics_path
-
     def initialize
       super
       @registry = ::Prometheus::Client.registry

--- a/lib/fluent/plugin/in_prometheus.rb
+++ b/lib/fluent/plugin/in_prometheus.rb
@@ -150,7 +150,7 @@ module Fluent::Plugin
     end
 
     def send_request_to_each_worker
-      bind == '0.0.0.0' ? '127.0.0.1' : @bind
+      bind = (@bind == '0.0.0.0') ? '127.0.0.1' : @bind
       req = Net::HTTP::Get.new(@metrics_path)
       [*(@base_port...(@base_port + @num_workers))].each do |worker_port|
         do_request(host: bind, port: worker_port) do |http|


### PR DESCRIPTION
To prepare for using HTTP helper. 
https://github.com/fluent/fluent-plugin-prometheus/pull/136 doesn't allow uses to use `extra_conf`. I'm going to change using webrick if users specify `extra_conf` so that use can use it in the next version(even if it's deprecated).  To do it, it needs to be `proc` form .