### PR TITLE
self-request should be called in async context 

### DIFF
--- a/lib/fluent/plugin/in_prometheus.rb
+++ b/lib/fluent/plugin/in_prometheus.rb
@@ -73,6 +73,14 @@ module Fluent::Plugin
         return
       end
 
+      begin
+        require 'async'
+        require 'fluent/plugin/in_prometheus/async_wrapper'
+        extend AsyncWrapper
+      rescue LoadError => _
+        # ignore
+      end
+
       tls_opt = if @ssl && @ssl['enable']
                   ssl_config = {}
 
@@ -204,6 +212,7 @@ module Fluent::Plugin
       end
     end
 
+    # might be replaced by AsyncWrapper if async gem is installed
     def do_request(host:, port:, secure:)
       http = Net::HTTP.new(host, port)
 

--- a/lib/fluent/plugin/in_prometheus.rb
+++ b/lib/fluent/plugin/in_prometheus.rb
@@ -197,10 +197,9 @@ module Fluent::Plugin
 
     def send_request_to_each_worker
       bind = (@bind == '0.0.0.0') ? '127.0.0.1' : @bind
-      req = Net::HTTP::Get.new(@metrics_path)
       [*(@base_port...(@base_port + @num_workers))].each do |worker_port|
         do_request(host: bind, port: worker_port, secure: @secure) do |http|
-          yield(http.request(req))
+          yield(http.get(@metrics_path))
         end
       end
     end

--- a/lib/fluent/plugin/in_prometheus.rb
+++ b/lib/fluent/plugin/in_prometheus.rb
@@ -185,7 +185,7 @@ module Fluent::Plugin
       full_result = PromMetricsAggregator.new
 
       send_request_to_each_worker do |resp|
-        if resp.is_a?(Net::HTTPSuccess)
+        if resp.code.to_s == '200'
           full_result.add_metrics(resp.body)
         end
       end

--- a/lib/fluent/plugin/in_prometheus.rb
+++ b/lib/fluent/plugin/in_prometheus.rb
@@ -214,7 +214,7 @@ module Fluent::Plugin
         http.verify_mode = OpenSSL::SSL::VERIFY_NONE
       end
 
-       http.start do
+      http.start do
         yield(http)
       end
     end

--- a/lib/fluent/plugin/in_prometheus/async_wrapper.rb
+++ b/lib/fluent/plugin/in_prometheus/async_wrapper.rb
@@ -1,0 +1,46 @@
+require 'async'
+
+module Fluent::Plugin
+  class PrometheusInput
+    module AsyncWrapper
+      def do_request(host:, port:, secure:)
+        endpoint =
+          if secure
+            context = OpenSSL::SSL::SSLContext.new
+            context.verify_mode = OpenSSL::SSL::VERIFY_NONE
+            Async::HTTP::Endpoint.parse("https://#{host}:#{port}", ssl_context: context)
+          else
+            Async::HTTP::Endpoint.parse("http://#{host}:#{port}")
+          end
+
+        client = Async::HTTP::Client.new(endpoint)
+        yield(AsyncHttpWrapper.new(client))
+      end
+
+      Response = Struct.new(:code, :body, :headers)
+
+      class AsyncHttpWrapper
+        def initialize(http)
+          @http = http
+        end
+
+        def get(path)
+          error = nil
+          response = Async::Task.current.async {
+            begin
+              @http.get(path)
+            rescue => e               # Async::Reactor rescue all error. handle it by itself
+              error = e
+            end
+          }.wait
+
+          if error
+            raise error
+          end
+
+          Response.new(response.status.to_s, response.body.read, response.headers)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
 GET request made by net/http client is blocking while handing `/aggregated_metrics`.  So, async-sever can't accept new requests since main thread is blocked by `aggregated_metrics`'s net/http client. it can cause deadlock.

fixes https://github.com/fluent/fluent-plugin-prometheus/issues/159