### PR TITLE
Fix nil error when empty body is returned from /metrics

### DIFF
--- a/lib/fluent/plugin/in_prometheus/async_wrapper.rb
+++ b/lib/fluent/plugin/in_prometheus/async_wrapper.rb
@@ -38,7 +38,13 @@ module Fluent::Plugin
             raise error
           end
 
-          Response.new(response.status.to_s, response.body.read, response.headers)
+          body =
+            if response.body.nil?
+              ''
+            else
+              response.body.read
+            end
+          Response.new(response.status.to_s, body, response.headers)
         end
       end
     end


### PR DESCRIPTION
```
<source>
  @type prometheus
  port 27224
</source>
```

The above configuration causes NoMethodError when async-http is
available. This patch fixes the compatibility between WEBrick's response
object and async-http's response object.