### PR TITLE
Fix resource leak in async wrapper

### DIFF
--- a/lib/fluent/plugin/in_prometheus/async_wrapper.rb
+++ b/lib/fluent/plugin/in_prometheus/async_wrapper.rb
@@ -13,8 +13,9 @@ module Fluent::Plugin
             Async::HTTP::Endpoint.parse("http://#{host}:#{port}")
           end
 
-        client = Async::HTTP::Client.new(endpoint)
-        yield(AsyncHttpWrapper.new(client))
+        Async::HTTP::Client.open(endpoint) do |client|
+          yield(AsyncHttpWrapper.new(client))
+        end
       end
 
       Response = Struct.new(:code, :body, :headers)
@@ -38,7 +39,7 @@ module Fluent::Plugin
             raise error
           end
 
-          Response.new(response.status.to_s, response.body.read, response.headers)
+          Response.new(response.status.to_s, response.read, response.headers)
         end
       end
     end

--- a/lib/fluent/plugin/in_prometheus/async_wrapper.rb
+++ b/lib/fluent/plugin/in_prometheus/async_wrapper.rb
@@ -39,7 +39,7 @@ module Fluent::Plugin
             raise error
           end
 
-          Response.new(response.status.to_s, response.read, response.headers)
+          Response.new(response.status.to_s, response.read || '', response.headers)
         end
       end
     end


### PR DESCRIPTION
- Close Async::HTTP::Client explicitly by using Async::HTTP::Client.open
- Read whole response body to close Async::HTTP::Client correctly
  - See the comment in async-http issue https://github.com/socketry/async-http/issues/37#issuecomment-560189660

Signed-off-by: Kohei Suzuki <eagletmt@gmail.com>

----

This patch fixes EMFILE error described in #168 and includes the same fix with #169 .
It's also related to #170 (~not confirmed yet~ confirmed in our environment https://github.com/fluent/fluent-plugin-prometheus/issues/170#issuecomment-678782555).