### PR TITLE
Updating plugin to support latest prometheus ruby client version

### DIFF
--- a/fluent-plugin-prometheus.gemspec
+++ b/fluent-plugin-prometheus.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "fluentd", ">= 1.9.1", "< 2"
-  spec.add_dependency "prometheus-client", "< 0.10"
+  spec.add_dependency "prometheus-client", ">= 2.1.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"

--- a/lib/fluent/plugin/in_prometheus_monitor.rb
+++ b/lib/fluent/plugin/in_prometheus_monitor.rb
@@ -76,14 +76,14 @@ module Fluent::Plugin
 
         @monitor_info.each do |name, metric|
           if info[name]
-            metric.set(label, info[name])
+            metric.set(info[name], labels: label)
           end
         end
 
         timekeys = info["buffer_timekeys"]
         if timekeys && !timekeys.empty?
-          @buffer_newest_timekey.set(label, timekeys.max)
-          @buffer_oldest_timekey.set(label, timekeys.min)
+          @buffer_newest_timekey.set(timekeys.max, labels: label)
+          @buffer_oldest_timekey.set(timekeys.min, labels: label)
         end
       end
     end
@@ -100,7 +100,7 @@ module Fluent::Plugin
       if @registry.exist?(name)
         @registry.get(name)
       else
-        @registry.gauge(name, docstring)
+        @registry.gauge(name, docstring: docstring, labels: @base_labels.keys + [:plugin_id, :plugin_category, :type])
       end
     end
   end

--- a/lib/fluent/plugin/in_prometheus_output_monitor.rb
+++ b/lib/fluent/plugin/in_prometheus_output_monitor.rb
@@ -161,9 +161,9 @@ module Fluent::Plugin
         monitor_info.each do |name, metric|
           if info[name]
             if metric.is_a?(::Prometheus::Client::Gauge)
-              metric.set(label, info[name])
+              metric.set(info[name], labels: label)
             elsif metric.is_a?(::Prometheus::Client::Counter)
-              metric.increment(label, info[name] - metric.get(label))
+              metric.increment(by: info[name] - metric.get(labels: label), labels: label)
             end
           end
         end
@@ -172,9 +172,9 @@ module Fluent::Plugin
           instance_vars_info.each do |name, metric|
             if info['instance_variables'][name]
               if metric.is_a?(::Prometheus::Client::Gauge)
-                metric.set(label, info['instance_variables'][name])
+                metric.set(info['instance_variables'][name], labels: label)
               elsif metric.is_a?(::Prometheus::Client::Counter)
-                metric.increment(label, info['instance_variables'][name] - metric.get(label))
+                metric.increment(by: info['instance_variables'][name] - metric.get(labels: label), labels: label)
               end
             end
           end
@@ -193,7 +193,7 @@ module Fluent::Plugin
           if next_time && start_time
             wait = next_time - start_time
           end
-          @metrics[:retry_wait].set(label, wait.to_f)
+          @metrics[:retry_wait].set(wait.to_f, labels: label)
         end
       end
     end
@@ -209,7 +209,7 @@ module Fluent::Plugin
       if @registry.exist?(name)
         @registry.get(name)
       else
-        @registry.gauge(name, docstring)
+        @registry.gauge(name, docstring: docstring, labels: @base_labels.keys + [:plugin_id, :type])
       end
     end
 
@@ -217,7 +217,7 @@ module Fluent::Plugin
       if @registry.exist?(name)
         @registry.get(name)
       else
-        @registry.public_send(@gauge_or_counter, name, docstring)
+        @registry.public_send(@gauge_or_counter, name, docstring: docstring, labels: @base_labels.keys + [:plugin_id, :type])
       end
     end
   end

--- a/lib/fluent/plugin/in_prometheus_tail_monitor.rb
+++ b/lib/fluent/plugin/in_prometheus_tail_monitor.rb
@@ -73,8 +73,8 @@ module Fluent::Plugin
           # Very fragile implementation
           pe = watcher.instance_variable_get(:@pe)
           label = labels(info, watcher.path)
-          @metrics[:inode].set(label, pe.read_inode)
-          @metrics[:position].set(label, pe.read_pos)
+          @metrics[:inode].set(pe.read_inode, labels: label)
+          @metrics[:position].set(pe.read_pos, labels: label)
         end
       end
     end
@@ -91,7 +91,7 @@ module Fluent::Plugin
       if @registry.exist?(name)
         @registry.get(name)
       else
-        @registry.gauge(name, docstring)
+        @registry.gauge(name, docstring: docstring, labels: @base_labels.keys + [:plugin_id, :type, :path])
       end
     end
   end

--- a/lib/fluent/plugin/prometheus.rb
+++ b/lib/fluent/plugin/prometheus.rb
@@ -188,7 +188,7 @@ module Fluent
           end
 
           begin
-            @gauge = registry.gauge(element['name'].to_sym, element['desc'])
+            @gauge = registry.gauge(element['name'].to_sym, docstring: element['desc'], labels: @base_labels.keys)
           rescue ::Prometheus::Client::Registry::AlreadyRegisteredError
             @gauge = Fluent::Plugin::Prometheus::Metric.get(registry, element['name'].to_sym, :gauge, element['desc'])
           end
@@ -201,7 +201,7 @@ module Fluent
             value = @key.call(record)
           end
           if value
-            @gauge.set(labels(record, expander), value)
+            @gauge.set(value, labels: labels(record, expander))
           end
         end
       end
@@ -210,7 +210,7 @@ module Fluent
         def initialize(element, registry, labels)
           super
           begin
-            @counter = registry.counter(element['name'].to_sym, element['desc'])
+            @counter = registry.counter(element['name'].to_sym, docstring: element['desc'], labels: @base_labels.keys)
           rescue ::Prometheus::Client::Registry::AlreadyRegisteredError
             @counter = Fluent::Plugin::Prometheus::Metric.get(registry, element['name'].to_sym, :counter, element['desc'])
           end
@@ -229,7 +229,7 @@ module Fluent
           # ignore if record value is nil
           return if value.nil?
 
-          @counter.increment(labels(record, expander), value)
+          @counter.increment(by: value, labels: labels(record, expander))
         end
       end
 
@@ -241,7 +241,7 @@ module Fluent
           end
 
           begin
-            @summary = registry.summary(element['name'].to_sym, element['desc'])
+            @summary = registry.summary(element['name'].to_sym, docstring: element['desc'], labels: @base_labels.keys)
           rescue ::Prometheus::Client::Registry::AlreadyRegisteredError
             @summary = Fluent::Plugin::Prometheus::Metric.get(registry, element['name'].to_sym, :summary, element['desc'])
           end
@@ -254,7 +254,7 @@ module Fluent
             value = @key.call(record)
           end
           if value
-            @summary.observe(labels(record, expander), value)
+            @summary.observe(value, labels: labels(record, expander))
           end
         end
       end
@@ -271,9 +271,9 @@ module Fluent
               buckets = element['buckets'].split(/,/).map(&:strip).map do |e|
                 e[/\A\d+.\d+\Z/] ? e.to_f : e.to_i
               end
-              @histogram = registry.histogram(element['name'].to_sym, element['desc'], {}, buckets)
+              @histogram = registry.histogram(element['name'].to_sym, docstring: element['desc'], labels: @base_labels.keys, buckets: buckets)
             else
-              @histogram = registry.histogram(element['name'].to_sym, element['desc'])
+              @histogram = registry.histogram(element['name'].to_sym, docstring: element['desc'], labels: @base_labels.keys)
             end
           rescue ::Prometheus::Client::Registry::AlreadyRegisteredError
             @histogram = Fluent::Plugin::Prometheus::Metric.get(registry, element['name'].to_sym, :histogram, element['desc'])
@@ -287,7 +287,7 @@ module Fluent
             value = @key.call(record)
           end
           if value
-            @histogram.observe(labels(record, expander), value)
+            @histogram.observe(value, labels: labels(record, expander))
           end
         end
       end

--- a/spec/fluent/plugin/shared.rb
+++ b/spec/fluent/plugin/shared.rb
@@ -178,20 +178,19 @@ shared_examples_for 'instruments record' do
 
     it 'instruments counter metric' do
       expect(counter.type).to eq(:counter)
-      expect(counter.get({test_key: 'test_value', key: 'foo1'})).to be_kind_of(Numeric)
-      expect(counter_with_accessor.get({test_key: 'test_value', key: 'foo6'})).to be_kind_of(Numeric)
+      expect(counter.get(labels: {test_key: 'test_value', key: 'foo1'})).to be_kind_of(Numeric)
+      expect(counter_with_accessor.get(labels: {test_key: 'test_value', key: 'foo6'})).to be_kind_of(Numeric)
     end
 
     it 'instruments gauge metric' do
       expect(gauge.type).to eq(:gauge)
-      expect(gauge.get({test_key: 'test_value', key: 'foo2'})).to eq(100)
+      expect(gauge.get(labels: {test_key: 'test_value', key: 'foo2'})).to eq(100)
     end
 
     it 'instruments summary metric' do
       expect(summary.type).to eq(:summary)
-      expect(summary.get({test_key: 'test_value', key: 'foo3'})).to be_kind_of(Hash)
-      expect(summary.get({test_key: 'test_value', key: 'foo3'})[0.99]).to eq(100)
-      expect(summary_with_accessor.get({test_key: 'test_value', key: 'foo5'})[0.99]).to eq(100)
+      expect(summary.get(labels: {test_key: 'test_value', key: 'foo3'})).to be_kind_of(Hash)
+      expect(summary_with_accessor.get(labels: {test_key: 'test_value', key: 'foo5'})["sum"]).to eq(100)
     end
 
     it 'instruments histogram metric' do
@@ -200,8 +199,8 @@ shared_examples_for 'instruments record' do
       end
 
       expect(histogram.type).to eq(:histogram)
-      expect(histogram.get({test_key: 'test_value', key: 'foo4'})).to be_kind_of(Hash)
-      expect(histogram.get({test_key: 'test_value', key: 'foo4'})[10]).to eq(5) # 4 + `es` in before
+      expect(histogram.get(labels: {test_key: 'test_value', key: 'foo4'})).to be_kind_of(Hash)
+      expect(histogram.get(labels: {test_key: 'test_value', key: 'foo4'})["10"]).to eq(5) # 4 + `es` in before
     end
   end
 
@@ -231,7 +230,7 @@ shared_examples_for 'instruments record' do
       expect(counter).to be_kind_of(::Prometheus::Client::Metric)
       key, _ = counter.values.find {|k,v| v ==  100 }
       expect(key).to be_kind_of(Hash)
-      expect(key[:foo]).to eq(100)
+      expect(key[:foo]).to eq("100")
     end
   end
 


### PR DESCRIPTION
Hello,

I would like to implement the following feature of the ruby prom client: [init_label_set](https://github.com/prometheus/client_ruby/commit/0e0f17fb38f2e703f8adfaf16d75b26af32b5053) that would allow metric init if specified by user in `fluent.conf`.

Though current `fluent-plugin-prometheus` build is blocked to old versions `<0.10` of prometheus ruby client. `init_label_set` method is only available in recent versions.

**This PR thus aims at using latest prom client version.**

In detail
- fixing method signatures to match the recent versions of prometheus client
- fixing now mandatory declaration of labels at initialization of metrics
- updating tests to reflect changes
- updating internal monitoring plugins to reflect change

**Please note the loss of summary metric quantiles as removed** [in this Pull Request on prometheus-client repo](https://github.com/prometheus/client_ruby/commit/ce6d44dea95f8af7f4d772c68cd2775f6668ec2d#diff-5c6ce0aabc4ad15a8a5936f64539effa83b035cfc1b74e43a7e7db5a6b618feb)
This effectively means that any summary metric will no longer display quantile labels (e.g. `quantile="0.99"`) but only `sum` and `count`.
Though personal experience on production environments showed anyway fluentd performance issues when over-using summary quantile computations. [Prefer thus histograms instead - with custom buckets if needed](https://github.com/fluent/fluent-plugin-prometheus#histogram-type) - and computation of quantiles on prometheus server side. [See the prometheus official documentation on this topic here.](https://prometheus.io/docs/practices/histograms/)