### PR TITLE
Adding init_label_set method from prometheus ruby client

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,9 @@ For details of each metric type, see [Prometheus documentation](http://prometheu
 - `type`: metric type (required)
 - `desc`: description of this metric (required)
 - `key`: key name of record for instrumentation (**optional**)
+- `initialized`: boolean controlling initilization of metric (**optional**). See [Metric initialization](#metric-initialization)
 - `<labels>`: additional labels for this metric (optional). See [Labels](#labels)
+- `<initlabels>`: labels to use for initialization of ReccordAccessors/Placeholder labels (**optional**). See [Metric initialization](#metric-initialization)
 
 If key is empty, the metric values is treated as 1, so the counter increments by 1 on each record regardless of contents of the record.
 
@@ -310,7 +312,9 @@ If key is empty, the metric values is treated as 1, so the counter increments by
 - `type`: metric type (required)
 - `desc`: description of metric (required)
 - `key`: key name of record for instrumentation (required)
+- `initialized`: boolean controlling initilization of metric (**optional**). See [Metric initialization](#metric-initialization)
 - `<labels>`: additional labels for this metric (optional). See [Labels](#labels)
+- `<initlabels>`: labels to use for initialization of ReccordAccessors/Placeholder labels (**optional**). See [Metric initialization](#metric-initialization)
 
 ### summary type
 
@@ -332,7 +336,9 @@ If key is empty, the metric values is treated as 1, so the counter increments by
 - `type`: metric type (required)
 - `desc`: description of metric (required)
 - `key`: key name of record for instrumentation (required)
+- `initialized`: boolean controlling initilization of metric (**optional**). See [Metric initialization](#metric-initialization)
 - `<labels>`: additional labels for this metric (optional). See [Labels](#labels)
+- `<initlabels>`: labels to use for initialization of ReccordAccessors/Placeholder labels (**optional**). See [Metric initialization](#metric-initialization)
 
 ### histogram type
 
@@ -355,8 +361,10 @@ If key is empty, the metric values is treated as 1, so the counter increments by
 - `type`: metric type (required)
 - `desc`: description of metric (required)
 - `key`: key name of record for instrumentation (required)
+- `initialized`: boolean controlling initilization of metric (**optional**). See [Metric initialization](#metric-initialization)
 - `buckets`: buckets of record for instrumentation (optional)
 - `<labels>`: additional labels for this metric (optional). See [Labels](#labels)
+- `<initlabels>`: labels to use for initialization of ReccordAccessors/Placeholder labels (**optional**). See [Metric initialization](#metric-initialization)
 
 ## Labels
 
@@ -394,6 +402,53 @@ Reserved placeholders are:
 - `${tag_suffix[N]}` refers to the [`tagsize`-1-N..] part of the tag.
   - where `tagsize` is the size of tag which is splitted with `.` (when tag is `1.2.3`, then `tagsize` is 3)
   - only available in Prometheus output/filter plugin
+
+### Metric initialization
+
+You can configure if a metric should be initialized to its zero value before receiving any event. To do so you just need to specify `initialized true`.
+
+```
+<metric>
+  name message_bar_counter
+  type counter
+  desc The total number of bar in message.
+  key bar
+  initialized true
+  <labels>
+    foo bar
+  </labels>
+</metric>
+```
+
+If your labels contains ReccordAccessors or Placeholders, you must use `<initlabels>` to specify the values your ReccordAccessors/Placeholders will take. This feature is useful only if your Placeholders/ReccordAccessors contain deterministic values. Initialization will create as many zero value metrics as `<initlabels>` blocks you defined.
+Potential reserved placeholders `${hostname}` and `${worker_id}`, as well as static labels, are automatically added and should not be specified in `<initlabels>` configuration.
+
+```
+<metric>
+  name message_bar_counter
+  type counter
+  desc The total number of bar in message.
+  key bar
+  initialized true
+  <labels>
+    key $.foo
+    tag ${tag}
+    foo bar
+    worker_id ${worker_id}
+  </labels>
+  <initlabels>
+    key foo1
+    tag tag1
+  </initlabels>
+  <initlabels>
+    key foo2
+    tag tag2
+  </initlabels>
+</metric>
+<labels>
+  hostname ${hostname}
+</labels>
+```
 
 ### top-level labels and labels inside metric
 

--- a/spec/fluent/plugin/in_prometheus_spec.rb
+++ b/spec/fluent/plugin/in_prometheus_spec.rb
@@ -202,7 +202,7 @@ describe Fluent::Plugin::PrometheusInput do
   describe '#run_multi_workers' do
     context '/metrics' do
       Fluent::SystemConfig.overwrite_system_config('workers' => 4) do
-        let(:config) { CONFIG + %[
+        let(:config) { FULL_CONFIG + %[
           port #{port - 2}
         ] }
 

--- a/spec/fluent/plugin/out_prometheus_spec.rb
+++ b/spec/fluent/plugin/out_prometheus_spec.rb
@@ -16,6 +16,10 @@ describe Fluent::Plugin::PrometheusOutput do
     it_behaves_like 'output configuration'
   end
 
+  describe '#testinitlabels' do
+    it_behaves_like 'initalized metrics'
+  end
+  
   describe '#run' do
     let(:message) { {"foo" => 100, "bar" => 100, "baz" => 100, "qux" => 10} }
 


### PR DESCRIPTION
Hello,

Preview to get feedback, will add tests if accepted on principle.

Following https://github.com/fluent/fluent-plugin-prometheus/pull/180 here is a PR to add the `init_label_set` feature from prometheus ruby client (see https://github.com/prometheus/client_ruby/commit/0e0f17fb38f2e703f8adfaf16d75b26af32b5053)

Here is what it gives with this implem

fluent.conf
```xml
 <source>
    @type tcp
    format json
    bind "0.0.0.0"
    port 5170
    tag "test"
    <parse>
      @type json
    </parse>
  </source>
  <match test>
    @type prometheus
    <metric>
      name histogram
      type histogram
      desc histogram with current implem, not initialized until first event
      key test
      <labels>
        label a
      </labels>
    </metric>
    <metric>
      name histogram_initialized
      type histogram
      desc histogram initialized
      key test
      buckets 0, 1, 10, 1000
      <labels>
        iam initialized!
      </labels>
      <initlabels>
        iam initialized!
      </initlabels>
    </metric>
    <metric>
      name alert_counter_initalized
      type counter
      desc User knowing part of/all future values of reccordAccessor $.filename can initialize the corresponding counters
      <labels>
        filename $.filename
      </labels>
      <initlabels>
        filename foo.txt
      </initlabels>
      <initlabels>
        filename foo.tar.gz
      </initlabels>
    </metric>
    <metric>
      name simple_summary_initialized
      type summary
      desc Providing no initlabels in the block yields a simple initialized metric
      key test
      <initlabels>
      </initlabels>
    </metric>
  </match>
  <match>
    @type prometheus
    <metric>
      name counter
      type counter
      desc string labels must be identical between labels and initlabels blocks
      key test
      <labels>
        source fluentd
        filename $.filename
      </labels>
      <initlabels>
        source fluentd
        filename foo.tar.gz
      </initlabels>
      <initlabels>
        source fluentd
        filename foo.txt
      </initlabels>
    </metric>
  </match>
  <match>
    @type prometheus
    <labels>
      globallabel initvalue2
    </labels>
    <metric>
      name counter_with_global_label
      type counter
      desc Identically, global labels must be initialized in initlabels block
      <labels>
        locallabel $.key
      </labels>
      <initlabels>
        locallabel initvalue
        globallabel initvalue2
      </initlabels>
    </metric>
  </match>
  <source>
    @type prometheus
  </source>
```

result
```bash
$ curl http://localhost:24231/metrics
# TYPE histogram histogram
# HELP histogram histogram with current implem, not initialized until first event
# TYPE histogram_initialized histogram
# HELP histogram_initialized histogram initialized
histogram_initialized_bucket{iam="initialized!",le="0"} 0.0
histogram_initialized_bucket{iam="initialized!",le="1"} 0.0
histogram_initialized_bucket{iam="initialized!",le="10"} 0.0
histogram_initialized_bucket{iam="initialized!",le="1000.0"} 0.0
histogram_initialized_bucket{iam="initialized!",le="+Inf"} 0.0
histogram_initialized_sum{iam="initialized!"} 0.0
histogram_initialized_count{iam="initialized!"} 0.0
# TYPE alert_counter_initalized counter
# HELP alert_counter_initalized User knowing part of/all future values of reccordAccessor $.filename can initialize the corresponding counters
alert_counter_initalized{filename="foo.txt"} 0.0
alert_counter_initalized{filename="foo.tar.gz"} 0.0
# TYPE simple_summary_initialized summary
# HELP simple_summary_initialized Providing no initlabels in the block yields a simple initialized metric
simple_summary_initialized_sum 0.0
simple_summary_initialized_count 0.0
# TYPE counter counter
# HELP counter string labels must be identical between labels and initlabels blocks
counter{source="fluentd",filename="foo.tar.gz"} 0.0
counter{source="fluentd",filename="foo.txt"} 0.0
# TYPE counter_with_global_label counter
# HELP counter_with_global_label Identically, global labels must be initialized in initlabels block
counter_with_global_label{locallabel="initvalue",globallabel="initvalue2"} 0.0
```

Example of things that triggers configError with this implem

Having initlabels not matching a string value from label (metric would never be used)
```xml
  <match test>
    @type prometheus
    <metric>
      name counter
      type counter
      desc histogram with current implem, not initialized until first event
      <labels>
        label a
      </labels>
      <initlabels>
        label b ---> would trigger error because value a is expected on whole lifetime of metric
      </initlabels>
    </metric>
  </match>
```

Having initlabels not matching the signature of labels
```xml
  <match test>
    @type prometheus
    <metric>
      name counter
      type counter
      desc histogram with current implem, not initialized until first event
      <labels>
        somelabel a
        anotherlabel b
      </labels>
      <initlabels>
        somelabel a
        someinitlabel b ---> would trigger error because someinitlabel is not present in <labels> block, this has no meaning
      </initlabels>
    </metric>
  </match>
```