### PR TITLE
fix: allow for lookup by symbol as well as string

### DIFF
--- a/lib/fluent/plugin/prometheus.rb
+++ b/lib/fluent/plugin/prometheus.rb
@@ -87,15 +87,14 @@ module Fluent
 
       def stringify_keys(hash_to_stringify)
         # Adapted from: https://www.jvt.me/posts/2019/09/07/ruby-hash-keys-string-symbol/
-        h = hash_to_stringify.map do |k,v|
-          v_str = if v.instance_of? Hash
-                    v.stringify_keys
-                  else
-                    v
-                  end
-          [k.to_s, v_str]
-        end
-        Hash[h]
+        hash_to_stringify.map do |k,v|
+          value_or_hash = if v.instance_of? Hash
+                            stringify_keys(v)
+                          else
+                            v
+                          end
+          [k.to_s, value_or_hash]
+        end.to_h
       end
 
       def configure(conf)

--- a/spec/fluent/plugin/out_prometheus_spec.rb
+++ b/spec/fluent/plugin/out_prometheus_spec.rb
@@ -40,4 +40,29 @@ describe Fluent::Plugin::PrometheusOutput do
 
     it_behaves_like 'instruments record'
   end
+
+  describe '#run with symbolized keys' do
+    let(:message) { {:foo => 100, :bar => 100, :baz => 100, :qux => 10} }
+
+    context 'simple config' do
+      let(:config) {
+        BASE_CONFIG + %(
+          <metric>
+            name simple
+            type counter
+            desc Something foo.
+            key foo
+          </metric>
+        )
+      }
+
+      it 'adds a new counter metric' do
+        expect(registry.metrics.map(&:name)).not_to eq([:simple])
+        driver.run(default_tag: tag) { driver.feed(event_time, message) }
+        expect(registry.metrics.map(&:name)).to eq([:simple])
+      end
+    end
+
+    it_behaves_like 'instruments record'
+  end
 end


### PR DESCRIPTION
I've noticed in my testing of this plugin, that sometimes I'm not able to instrument my metrics properly. Even though I know that I'm sending correct values, the prometheus plugin doesn't seem to ever pick up the changes.

After doing a fair amount of debugging, I've found that sometimes fluentd will pass the Hash's of my messages to the prometheus plugin using symbols to key the hash instead of strings. As Ruby treats symbols as different than strings, this means that the prometheus plugin isn't able to parse the message.

Here is an example of one such message...

When I output it from my plugin it is sent as:
```
{"name":"foo-6b87bf6b57-46czk","count":6472}
```
If I insert debug logging into the metric instrumentation method of this plugin, here is what it receives from fluentd:
```
{:name=>"foo-6b87bf6b57-46czk", :count=>6472}
```

This fails, when it tries to use the key, I provide in my config:
```
    <metric>
      name fluentd_custom_lines_by_podname
      type counter
      desc The total number of lines received by podname
      key count
    </metric>
```

Because it essentially tries to use `record["count"]` when it instead needs to be using `record[:count]`

This PR changes the default functionality for all instrumentations to fallback to using symbols if indexing by string fails to work properly.