### PR TITLE
Follow Fluentd's core metrics mechanism change

### DIFF
--- a/lib/fluent/plugin/in_prometheus_output_monitor.rb
+++ b/lib/fluent/plugin/in_prometheus_output_monitor.rb
@@ -144,7 +144,16 @@ module Fluent::Plugin
 
         # output metrics
         'retry_count' => @metrics[:retry_counts],
+        # Needed since Fluentd v1.14 due to metrics extensions.
+        'num_errors' => @metrics[:num_errors],
+        'write_count' => @metrics[:write_count],
+        'emit_count' => @metrics[:emit_count],
+        'emit_records' => @metrics[:emit_records],
+        'rollback_count' => @metrics[:rollback_count],
+        'flush_time_count' => @metrics[:flush_time_count],
+        'slow_flush_count' => @metrics[:slow_flush_count],
       }
+      # No needed for Fluentd v1.14 but leave as-is for backward compatibility.
       instance_vars_info = {
         num_errors: @metrics[:num_errors],
         write_count: @metrics[:write_count],


### PR DESCRIPTION
With metrics plugin extension, output metrics should be put in monitor_info not instance variables.

Instance variables: `num_errors`, `write_count`, `emit_count`, `emit_records`, `rollback_count`, `flush_time_count`, `slow_flush_count` are gone after Fluentd's metrics plugin mechanism is enabled.


Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>