### PR TITLE
CI: Disable CI on Ruby head

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -15,10 +15,6 @@ jobs:
         os:
           - ubuntu-latest
         experimental: [false]
-        include:
-          - ruby: head
-            os: ubuntu-latest
-            experimental: true
     name: Ruby ${{ matrix.ruby }} unit testing on ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Since we don't update this plugin so often these days, no need to check on Ruby pre-release.