### PR TITLE
Fix metrics name for "fluentd_output_status_buffer_queue_byte_size"

### DIFF
--- a/lib/fluent/plugin/in_prometheus_output_monitor.rb
+++ b/lib/fluent/plugin/in_prometheus_output_monitor.rb
@@ -77,7 +77,7 @@ module Fluent::Plugin
           :fluentd_output_status_buffer_queue_length,
           'Current length of queue buffers.'),
         buffer_queue_byte_size: get_gauge(
-          :fluentd_output_status_queue_byte_size,
+          :fluentd_output_status_buffer_queue_byte_size,
           'Current total size of queue buffers.'),
         buffer_available_buffer_space_ratios: get_gauge(
           :fluentd_output_status_buffer_available_space_ratio,


### PR DESCRIPTION
In the `README.md` file, there is a description for `fluentd_output_status_buffer_queue_byte_size`, but it cannot be found in the source code. I would like to modify the name of the metrics in the source code to match the description in the `README.md` file.