### PR TITLE
Add gzip support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ More configuration parameters:
 - `port`: listen port (default: 24231)
 - `metrics_path`: metrics HTTP endpoint (default: /metrics)
 - `aggregated_metrics_path`: metrics HTTP endpoint (default: /aggregated_metrics)
-- `content_encoding`: encoding format for the exposed metrics (default: identity)
+- `content_encoding`: encoding format for the exposed metrics (default: identity). Supported formats are {identity, gzip}
 
 When using multiple workers, each worker binds to port + `fluent_worker_id`.
 To scrape metrics from all workers at once, you can access http://localhost:24231/aggregated_metrics.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ More configuration parameters:
 - `port`: listen port (default: 24231)
 - `metrics_path`: metrics HTTP endpoint (default: /metrics)
 - `aggregated_metrics_path`: metrics HTTP endpoint (default: /aggregated_metrics)
+- `content_encoding`: encoding format for the exposed metrics (default: identity)
 
 When using multiple workers, each worker binds to port + `fluent_worker_id`.
 To scrape metrics from all workers at once, you can access http://localhost:24231/aggregated_metrics.

--- a/fluent-plugin-prometheus.gemspec
+++ b/fluent-plugin-prometheus.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "fluentd", ">= 1.9.1", "< 2"
   spec.add_dependency "prometheus-client", ">= 2.1.0"
+  spec.add_dependency "zlib", ">=3.0.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"

--- a/fluent-plugin-prometheus.gemspec
+++ b/fluent-plugin-prometheus.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "fluentd", ">= 1.9.1", "< 2"
   spec.add_dependency "prometheus-client", ">= 2.1.0"
-  spec.add_dependency "zlib", ">=3.0.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"

--- a/lib/fluent/plugin/in_prometheus.rb
+++ b/lib/fluent/plugin/in_prometheus.rb
@@ -188,7 +188,7 @@ module Fluent::Plugin
     end
 
     def all_metrics
-      response_headers(::Prometheus::Client::Formats::Text.marshal(@registry))
+      response(::Prometheus::Client::Formats::Text.marshal(@registry))
     rescue => e
       [500, { 'Content-Type' => 'text/plain' }, e.to_s]
     end
@@ -201,7 +201,7 @@ module Fluent::Plugin
           full_result.add_metrics(resp.body)
         end
       end
-      response_headers(full_result.get_metrics)
+      response(full_result.get_metrics)
     rescue => e
       [500, { 'Content-Type' => 'text/plain' }, e.to_s]
     end
@@ -230,7 +230,7 @@ module Fluent::Plugin
       end
     end
 
-    def response_headers(metrics)
+    def response(metrics)
       body = nil
       case @content_encoding
       when :gzip

--- a/spec/fluent/plugin/in_prometheus_spec.rb
+++ b/spec/fluent/plugin/in_prometheus_spec.rb
@@ -45,6 +45,24 @@ describe Fluent::Plugin::PrometheusInput do
         expect(driver.instance.metrics_path).to eq('/_test')
       end
     end
+
+    describe 'content_encoding_identity' do
+      let(:config) { CONFIG + %[
+    content_encoding identity
+] }
+      it 'should be configurable' do
+        expect(driver.instance.content_encoding).to eq(:identity)
+      end
+    end
+
+    describe 'content_encoding_gzip' do
+      let(:config) { CONFIG + %[
+    content_encoding gzip
+] }
+      it 'should be configurable' do
+        expect(driver.instance.content_encoding).to eq(:gzip)
+      end
+    end
   end
 
   describe '#start' do
@@ -193,6 +211,40 @@ describe Fluent::Plugin::PrometheusInput do
             req = Net::HTTP::Get.new("/foo")
             res = http.request(req)
             expect(res.code).not_to eq('200')
+          end
+        end
+      end
+    end
+
+    context 'response content_encoding identity' do
+      let(:config) { LOCAL_CONFIG + %[
+        content_encoding identity
+  ] }
+      it 'exposes metric' do
+        driver.run(timeout: 1) do
+          registry = driver.instance.instance_variable_get(:@registry)
+          registry.counter(:test,docstring: "Testing metrics") unless registry.exist?(:test)
+          Net::HTTP.start("127.0.0.1", port) do |http|
+            req = Net::HTTP::Get.new("/metrics")
+            res = http.request(req)
+            expect(res.body).to include("test Testing metrics")
+          end
+        end
+      end
+    end
+
+    context 'response content_encoding gzip' do
+      let(:config) { LOCAL_CONFIG + %[
+        content_encoding gzip
+  ] }
+      it 'exposes metric' do
+        driver.run(timeout: 1) do
+          registry = driver.instance.instance_variable_get(:@registry)
+          registry.counter(:test,docstring: "Testing metrics") unless registry.exist?(:test)
+          Net::HTTP.start("127.0.0.1", port) do |http|
+            req = Net::HTTP::Get.new("/metrics")
+            res = http.request(req)
+            expect(res.body).to include("test Testing metrics")
           end
         end
       end


### PR DESCRIPTION
Added support for gzip compression while exposing metrics. 
Tested locally with prometheus server
![image](https://github.com/user-attachments/assets/468d4b45-554a-4fd7-8679-acff8860a485)

#219 