### PR TITLE
Add throttling metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ This plugin uses internal class of Fluentd, so it's easy to break.
 - `fluentd_tail_file_closed`: Number of closed files
 - `fluentd_tail_file_opened`: Number of opened files
 - `fluentd_tail_file_rotated`: Number of rotated files
-- `fluentd_tail_file_throttled`: Number of throttled files
+- `fluentd_tail_file_throttled`: Number of times files got throttled (only with fluentd version > 1.17)
 
 Default labels:
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ This plugin uses internal class of Fluentd, so it's easy to break.
 - `fluentd_tail_file_closed`: Number of closed files
 - `fluentd_tail_file_opened`: Number of opened files
 - `fluentd_tail_file_rotated`: Number of rotated files
+- `fluentd_tail_file_throttled`: Number of throttled files
 
 Default labels:
 

--- a/lib/fluent/plugin/in_prometheus_tail_monitor.rb
+++ b/lib/fluent/plugin/in_prometheus_tail_monitor.rb
@@ -62,7 +62,7 @@ module Fluent::Plugin
           'Number of files rotated.'),
         throttled_file_metrics: get_gauge(
           :fluentd_tail_file_throttled,
-          'Number of files throttled.'),
+          'Number of times files got throttled.'),
       }
       timer_execute(:in_prometheus_tail_monitor, @interval, &method(:update_monitor_info))
     end
@@ -92,7 +92,7 @@ module Fluent::Plugin
             @metrics[:closed_file_metrics].set(monitor_info.closed.get, labels: label)
             @metrics[:opened_file_metrics].set(monitor_info.opened.get, labels: label)
             @metrics[:rotated_file_metrics].set(monitor_info.rotated.get, labels: label)
-            @metrics[:throttled_file_metrics].set(monitor_info.throttled.get, labels: label)
+            @metrics[:throttled_file_metrics].set(monitor_info.throttled.get, labels: label) if monitor_info.members.include?(:throttled)
           end
         end
       end

--- a/lib/fluent/plugin/in_prometheus_tail_monitor.rb
+++ b/lib/fluent/plugin/in_prometheus_tail_monitor.rb
@@ -60,6 +60,9 @@ module Fluent::Plugin
         rotated_file_metrics: get_gauge(
           :fluentd_tail_file_rotated,
           'Number of files rotated.'),
+        throttled_file_metrics: get_gauge(
+          :fluentd_tail_file_throttled,
+          'Number of files throttled.'),
       }
       timer_execute(:in_prometheus_tail_monitor, @interval, &method(:update_monitor_info))
     end
@@ -89,6 +92,7 @@ module Fluent::Plugin
             @metrics[:closed_file_metrics].set(monitor_info.closed.get, labels: label)
             @metrics[:opened_file_metrics].set(monitor_info.opened.get, labels: label)
             @metrics[:rotated_file_metrics].set(monitor_info.rotated.get, labels: label)
+            @metrics[:throttled_file_metrics].set(monitor_info.throttled.get, labels: label)
           end
         end
       end


### PR DESCRIPTION
## Issues this PR solves
#190 
## Why is this PR needed?
Add observability on throttling in `in_tail` plugin
https://github.com/fluent/fluentd/pull/4578 - corresponding metrics PR in `in_tail` 