### PR TITLE
Fix warning on nil tag

### DIFF
--- a/lib/fluent/plugin/prometheus/placeholder_expander.rb
+++ b/lib/fluent/plugin/prometheus/placeholder_expander.rb
@@ -39,6 +39,8 @@ module Fluent
         private
 
         def build_tag(tag)
+          return [] if tag.nil?
+
           tags = tag.split('.')
 
           placeholders = { '${tag}' => tag }


### PR DESCRIPTION
Hi,

This aims at fixing warning we see in logs:
```
{"time":"2025-06-23","level":"warn","message":"send an error event stream to @ERROR: error_class=NoMethodError error=\"undefined method `split' for nil:NilClass\\n\\n          tags = tag.split('.')\\n                    ^^^^^^\" location=\"/fluentd/vendor/bundle/ruby/3.1.0/gems/fluent-plugin-prometheus-2.1.0/lib/fluent/plugin/prometheus/placeholder_expander.rb:42:in `build_tag'\" tag=nil","worker_id":0
```

I hope it is not too naive.

Thanks!