### PR TITLE
test: fix driver activity period

### DIFF
--- a/spec/fluent/plugin/shared.rb
+++ b/spec/fluent/plugin/shared.rb
@@ -289,7 +289,12 @@ end
 
 shared_examples_for 'instruments record' do
   before do
-    driver.run(default_tag: tag) { driver.feed(event_time, message) }
+    # Should not shut down driver because it will be used in subsequent tests.
+    driver.run(default_tag: tag, shutdown: false) { driver.feed(event_time, message) }
+  end
+
+  after do
+    driver.instance_shutdown
   end
 
   context 'full config' do


### PR DESCRIPTION
This PR prevent to shut down the driver used in subsequent tests. 
When we use timer plugin helper or other components that depend on the event loop, the driver does not operate as expected if it is shut down.

If you add timer plugin helper, you can confirm this behavior.

```diff
diff --git a/lib/fluent/plugin/filter_prometheus.rb b/lib/fluent/plugin/filter_prometheus.rb
index ccdfe78..ab3a889 100644
--- a/lib/fluent/plugin/filter_prometheus.rb
+++ b/lib/fluent/plugin/filter_prometheus.rb
@@ -7,6 +7,8 @@ class PrometheusFilter < Fluent::Plugin::Filter
     include Fluent::Plugin::PrometheusLabelParser
     include Fluent::Plugin::Prometheus
 
+    helpers :timer
+
     def initialize
       super
       @registry = ::Prometheus::Client.registry
```